### PR TITLE
Update outdated dependent projects

### DIFF
--- a/AE/Dockerfile
+++ b/AE/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 
 # install python3.8 and pip
 RUN apt-get install -y curl python3.8 python3.8-distutils
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
 RUN python3.8 get-pip.py
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,11 +19,10 @@ tf_configure(
 
 cuda_configure(name = "local_config_cuda")
 
-_RULES_BOOST_COMMIT = "652b21e35e4eeed5579e696da0facbe8dba52b1f"
+_RULES_BOOST_COMMIT = "96e9b631f104b43a53c21c87b01ac538ad6f3b48"
 
 http_archive(
     name = "com_github_nelhage_rules_boost",
-    sha256 = "c1b8b2adc3b4201683cf94dda7eef3fc0f4f4c0ea5caa3ed3feffe07e1fb5b15",
     strip_prefix = "rules_boost-%s" % _RULES_BOOST_COMMIT,
     urls = [
         "https://github.com/nelhage/rules_boost/archive/%s.tar.gz" % _RULES_BOOST_COMMIT,


### PR DESCRIPTION
Some dependent files and projects are outdated and broken.

* Default `get-pip.py` no longer supports py3.8; use the script under `pip/3.8` instead.
* The [rules_boos](https://github.com/nelhage/rules_boost) commit used originally no longer works; use another instead. However, since rules_boost is no longer maintained for lower versions of Bazel, this temporary fix cannot be guaranteed to work reliably in the long term.